### PR TITLE
Limit viewable channel on search

### DIFF
--- a/src/Utils/GetUserViewableChannel.ts
+++ b/src/Utils/GetUserViewableChannel.ts
@@ -1,0 +1,52 @@
+import { type Channel, PrismaClient } from "@prisma/client";
+
+/**
+ * 指定のユーザーが閲覧できるチャンネル情報を取得する
+ * @param _userId 
+ * @returns 
+ */
+export default async function GetUserViewableChannel(_userId: string): Promise<Channel[]> {
+  //PrismaClientのインスタンスを作成
+  const db = new PrismaClient();
+
+  //ユーザーのロールを取得
+  const userRolesLinks = await db.roleLink.findMany({
+    where: {
+      userId: _userId,
+    },
+    select: {
+      roleId: true,
+    },
+  });
+  //ユーザーのロールIdを配列化
+  const userRoleIds = userRolesLinks.map((role) => role.roleId);
+
+  //このユーザーが見れるチャンネルIdを取得
+  const viewableChannel =await db.channel.findMany({
+    where: {
+      OR: [
+        {
+          createdUserId: _userId,
+        },
+        {
+          ChannelViewableRole: {
+            some: {
+              roleId: {
+                in: userRoleIds
+              }
+            },
+          }
+        },
+        {
+          ChannelJoin: {
+            some: {
+              userId: _userId,
+            },
+          },
+        },
+      ],
+    },
+  }) as Channel[];
+
+  return viewableChannel;
+}

--- a/src/Utils/GetUserViewableChannel.ts
+++ b/src/Utils/GetUserViewableChannel.ts
@@ -1,4 +1,4 @@
-import {type Channel, PrismaClient} from "@prisma/client";
+import { type Channel, PrismaClient } from "@prisma/client";
 
 /**
  * 指定のユーザーが閲覧できるチャンネル情報を取得する
@@ -64,17 +64,17 @@ export default async function GetUserViewableChannel(
                   userId: _userId,
                 },
               },
-            }
+            },
           ],
         },
         _onlyJoinedChannel //参加しているチャンネルのみを取得する場合はチャンネルに参加しているか確認
           ? {
-            ChannelJoin: {
-              some: {
-                userId: _userId,
+              ChannelJoin: {
+                some: {
+                  userId: _userId,
+                },
               },
-            },
-          }
+            }
           : {},
       ],
     },

--- a/src/Utils/GetUserViewableChannel.ts
+++ b/src/Utils/GetUserViewableChannel.ts
@@ -1,4 +1,4 @@
-import { type Channel, PrismaClient } from "@prisma/client";
+import {type Channel, PrismaClient} from "@prisma/client";
 
 /**
  * 指定のユーザーが閲覧できるチャンネル情報を取得する
@@ -26,7 +26,7 @@ export default async function GetUserViewableChannel(
   const userRoleIds = userRolesLinks.map((role) => role.roleId);
 
   //このユーザーが見れるチャンネルIdを取得
-  const viewableChannel = (await db.channel.findMany({
+  return (await db.channel.findMany({
     where: {
       AND: [
         {
@@ -62,16 +62,14 @@ export default async function GetUserViewableChannel(
         },
         !_onlyJoinedChannel //参加しているチャンネルのみを取得する場合はチャンネルに参加しているか確認
           ? {
-              ChannelJoin: {
-                some: {
-                  userId: _userId,
-                },
+            ChannelJoin: {
+              some: {
+                userId: _userId,
               },
-            }
+            },
+          }
           : {},
       ],
     },
   })) as Channel[];
-
-  return viewableChannel;
 }

--- a/src/Utils/GetUserViewableChannel.ts
+++ b/src/Utils/GetUserViewableChannel.ts
@@ -2,10 +2,12 @@ import { type Channel, PrismaClient } from "@prisma/client";
 
 /**
  * 指定のユーザーが閲覧できるチャンネル情報を取得する
- * @param _userId 
- * @returns 
+ * @param _userId
+ * @returns
  */
-export default async function GetUserViewableChannel(_userId: string): Promise<Channel[]> {
+export default async function GetUserViewableChannel(
+  _userId: string,
+): Promise<Channel[]> {
   //PrismaClientのインスタンスを作成
   const db = new PrismaClient();
 
@@ -22,7 +24,7 @@ export default async function GetUserViewableChannel(_userId: string): Promise<C
   const userRoleIds = userRolesLinks.map((role) => role.roleId);
 
   //このユーザーが見れるチャンネルIdを取得
-  const viewableChannel =await db.channel.findMany({
+  const viewableChannel = (await db.channel.findMany({
     where: {
       OR: [
         {
@@ -32,10 +34,10 @@ export default async function GetUserViewableChannel(_userId: string): Promise<C
           ChannelViewableRole: {
             some: {
               roleId: {
-                in: userRoleIds
-              }
+                in: userRoleIds,
+              },
             },
-          }
+          },
         },
         {
           ChannelJoin: {
@@ -46,7 +48,7 @@ export default async function GetUserViewableChannel(_userId: string): Promise<C
         },
       ],
     },
-  }) as Channel[];
+  })) as Channel[];
 
   return viewableChannel;
 }

--- a/src/Utils/GetUserViewableChannel.ts
+++ b/src/Utils/GetUserViewableChannel.ts
@@ -30,11 +30,14 @@ export default async function GetUserViewableChannel(
     where: {
       AND: [
         {
-          OR: [ //ここで見れるチャンネルをすべて抜き出す
-            { //チャンネル作成者は見れる
+          OR: [
+            //ここで見れるチャンネルをすべて抜き出す
+            {
+              //チャンネル作成者は見れる
               createdUserId: _userId,
             },
-            { //閲覧ロールが設定されているもので自分のロールがあるなら見れる
+            {
+              //閲覧ロールが設定されているもので自分のロールがあるなら見れる
               ChannelViewableRole: {
                 some: {
                   roleId: {
@@ -45,7 +48,8 @@ export default async function GetUserViewableChannel(
             },
           ],
         },
-        { //チャンネルの閲覧限定ロールが設定されているもので、自分のロールが含まれないものは見れない
+        {
+          //チャンネルの閲覧限定ロールが設定されているもので、自分のロールが含まれないものは見れない
           NOT: {
             ChannelViewableRole: {
               some: {
@@ -54,18 +58,18 @@ export default async function GetUserViewableChannel(
                 },
               },
             },
-          }
+          },
         },
         !_onlyJoinedChannel //参加しているチャンネルのみを取得する場合はチャンネルに参加しているか確認
-            ? {
-                ChannelJoin: {
-                  some: {
-                    userId: _userId,
-                  },
+          ? {
+              ChannelJoin: {
+                some: {
+                  userId: _userId,
                 },
-              }
-            : {},
-      ]
+              },
+            }
+          : {},
+      ],
     },
   })) as Channel[];
 

--- a/src/Utils/GetUserViewableChannel.ts
+++ b/src/Utils/GetUserViewableChannel.ts
@@ -46,21 +46,28 @@ export default async function GetUserViewableChannel(
                 },
               },
             },
-          ],
-        },
-        {
-          //チャンネルの閲覧限定ロールが設定されているもので、自分のロールが含まれないものは見れない
-          NOT: {
-            ChannelViewableRole: {
-              some: {
-                roleId: {
-                  notIn: userRoleIds,
+            {
+              //チャンネルの閲覧限定ロールが設定されているもので、自分のロールが含まれないものは見れない
+              NOT: {
+                ChannelViewableRole: {
+                  some: {
+                    roleId: {
+                      notIn: userRoleIds,
+                    },
+                  },
                 },
               },
             },
-          },
+            {
+              ChannelJoin: {
+                some: {
+                  userId: _userId,
+                },
+              },
+            }
+          ],
         },
-        !_onlyJoinedChannel //参加しているチャンネルのみを取得する場合はチャンネルに参加しているか確認
+        _onlyJoinedChannel //参加しているチャンネルのみを取得する場合はチャンネルに参加しているか確認
           ? {
             ChannelJoin: {
               some: {

--- a/src/Utils/GetUserViewableChannel.ts
+++ b/src/Utils/GetUserViewableChannel.ts
@@ -45,7 +45,17 @@ export default async function GetUserViewableChannel(
             },
           ],
         },
-        {
+        { //チャンネルの閲覧限定ロールが設定されているもので、自分のロールが含まれないものは見れない
+          NOT: {
+            ChannelViewableRole: {
+              some: {
+                roleId: {
+                  notIn: userRoleIds,
+                },
+              },
+            },
+          }
+        },
         !_onlyJoinedChannel //参加しているチャンネルのみを取得する場合はチャンネルに参加しているか確認
             ? {
                 ChannelJoin: {

--- a/src/components/Message/message.module.ts
+++ b/src/components/Message/message.module.ts
@@ -242,7 +242,7 @@ export const message = new Elysia({ prefix: "/message" })
           throw error(403, "You are not allowed to view this channel");
         }
       } else {
-        const viewableChannels = await GetUserViewableChannel(_userId);
+        const viewableChannels = await GetUserViewableChannel(_userId, false);
         viewableChannelIds = viewableChannels.map((channel) => channel.id);
       }
 

--- a/src/components/Message/message.module.ts
+++ b/src/components/Message/message.module.ts
@@ -4,6 +4,7 @@ import { PrismaClient } from "@prisma/client";
 import Elysia, { error, t } from "elysia";
 import CheckToken, { urlPreviewControl } from "../../Middlewares";
 import CheckChannelVisibility from "../../Utils/CheckChannelVisitiblity";
+import GetUserViewableChannel from "../../Utils/GetUserViewableChannel";
 
 const db = new PrismaClient();
 
@@ -225,11 +226,25 @@ export const message = new Elysia({ prefix: "/message" })
         loadIndex,
         sort,
       },
+      _userId
     }) => {
       //デフォルトのソート順を設定
       if (sort === undefined) sort = "desc";
       //読み込みインデックス指定があるならスキップするメッセ数を計算
       const messageSkipping = loadIndex ? (loadIndex - 1) * 50 : 0;
+
+      //チャンネル指定が無かった時用のユーザーが閲覧できるチャンネルId配列
+      let viewableChannelIds: string[] = [];
+      //チャンネル指定があるなら閲覧制限を確認する、無いならユーザーが閲覧できるチャンネルを取得
+      if (channelId) {
+        //チャンネルの閲覧制限があるか確認
+        if (!(await CheckChannelVisibility(channelId, _userId))) {
+          throw error(403, "You are not allowed to view this channel");
+        }
+      } else {
+        const viewableChannels = await GetUserViewableChannel(_userId);
+        viewableChannelIds = viewableChannels.map((channel) => channel.id);
+      }
 
       //URLプレビューがあるかどうかの条件を変換
       const relationOptionGetter = (_opt: boolean | undefined) => {
@@ -253,7 +268,7 @@ export const message = new Elysia({ prefix: "/message" })
           content: {
             contains: content,
           },
-          channelId: channelId ? { equals: channelId } : undefined,
+          channelId: channelId ? { equals: channelId } : { in: viewableChannelIds },
           userId: userId ? { equals: userId } : undefined,
           MessageUrlPreview: relationOptionGetter(hasUrlPreview),
           MessageFileAttached: relationOptionGetter(hasFileAttachment),

--- a/src/components/Message/message.module.ts
+++ b/src/components/Message/message.module.ts
@@ -226,7 +226,7 @@ export const message = new Elysia({ prefix: "/message" })
         loadIndex,
         sort,
       },
-      _userId
+      _userId,
     }) => {
       //デフォルトのソート順を設定
       if (sort === undefined) sort = "desc";
@@ -268,7 +268,9 @@ export const message = new Elysia({ prefix: "/message" })
           content: {
             contains: content,
           },
-          channelId: channelId ? { equals: channelId } : { in: viewableChannelIds },
+          channelId: channelId
+            ? { equals: channelId }
+            : { in: viewableChannelIds },
           userId: userId ? { equals: userId } : undefined,
           MessageUrlPreview: relationOptionGetter(hasUrlPreview),
           MessageFileAttached: relationOptionGetter(hasFileAttachment),


### PR DESCRIPTION
メッセージ検索時に、結果を検索したユーザーが閲覧できるチャンネルからのもののみに制限する