### PR TITLE
Easier middleware returning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "giracle-backend",
       "dependencies": {
-        "@elysiajs/cors": "^1.4.1",
+        "@elysiajs/cors": "^1.4.2",
         "@elysiajs/swagger": "^1.3.1",
-        "@prisma/adapter-libsql": "^7.7.0",
-        "@prisma/client": "^7.7.0",
+        "@prisma/adapter-libsql": "^7.8.0",
+        "@prisma/client": "^7.8.0",
         "elysia": "latest",
         "image-size": "^2.0.2",
         "open-graph-scraper": "^6.11.0",
-        "prisma": "^7.7.0",
+        "prisma": "^7.8.0",
         "sharp": "^0.34.5",
       },
       "devDependencies": {
@@ -216,7 +216,7 @@
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
 

--- a/src/Middlewares.ts
+++ b/src/Middlewares.ts
@@ -65,7 +65,7 @@ export namespace Middleware {
           return status(401, "User is banned");
         }
         token.expires = new Date(now + ONE_MINUITE * 60 * 24 * 15);
-        return { _userId: cachedToken.userId };
+        return { CheckToken: { _userId: cachedToken.userId } };
       }
 
       //トークンがDBにあるか確認
@@ -99,9 +99,7 @@ export namespace Middleware {
       //トークンの期限を延長
       token.expires = new Date(now + 1000 * 60 * 60 * 24 * 15); //15日間有効
 
-      return {
-        _userId: tokenData.userId,
-      };
+      return { CheckToken: { _userId: tokenData.userId } };
     });
 
   export const CheckRoleTerm = new Elysia({ name: "checkRoleTerm" })
@@ -110,8 +108,9 @@ export namespace Middleware {
     .macro({
       checkRoleTerm(roleTerm: string) {
         return {
-          async beforeHandle({ _userId }) {
-            //console.log("Middlewares :: checkRoleTerm : 送信者のユーザーId->", _userId);
+          async beforeHandle({ CheckToken }) {
+            if (CheckToken === undefined) return status(401, "Unauthorized");
+            const _userId = CheckToken._userId;
 
             //該当権限を持つロール付与情報あるいはサーバー管理権限を検索
             const roleLink = await db.roleLink.findFirst({

--- a/src/components/Channel/channel.module.ts
+++ b/src/components/Channel/channel.module.ts
@@ -9,7 +9,7 @@ export const channel = new Elysia({ prefix: "/channel" })
   .use(Middleware.CheckToken)
   .post(
     "/join",
-    async ({ body: { channelId }, _userId, server }) => {
+    async ({ body: { channelId }, CheckToken: { _userId }, server }) => {
       //参加処理
       await ServiceChannel.Join(channelId, _userId);
 
@@ -59,7 +59,7 @@ export const channel = new Elysia({ prefix: "/channel" })
   )
   .post(
     "/leave",
-    async ({ body: { channelId }, _userId, server }) => {
+    async ({ body: { channelId }, CheckToken: { _userId }, server }) => {
       //チャンネル退出処理
       await ServiceChannel.Leave(channelId, _userId);
 
@@ -102,7 +102,7 @@ export const channel = new Elysia({ prefix: "/channel" })
   )
   .get(
     "/get-info/:channelId",
-    async ({ params: { channelId }, _userId }) => {
+    async ({ params: { channelId }, CheckToken: { _userId } }) => {
       const channelData = await ServiceChannel.GetInfo(channelId, _userId);
 
       return {
@@ -122,7 +122,7 @@ export const channel = new Elysia({ prefix: "/channel" })
   )
   .get(
     "/list",
-    async ({ _userId }) => {
+    async ({ CheckToken: { _userId } }) => {
       const ChannelList = await ServiceChannel.List(_userId);
 
       return {
@@ -139,7 +139,7 @@ export const channel = new Elysia({ prefix: "/channel" })
   )
   .post(
     "/get-history/:channelId",
-    async ({ params: { channelId }, body, _userId }) => {
+    async ({ params: { channelId }, body, CheckToken: { _userId } }) => {
       const results = await ServiceChannel.GetHistory(channelId, body, _userId);
 
       return {
@@ -174,7 +174,7 @@ export const channel = new Elysia({ prefix: "/channel" })
   )
   .get(
     "/search",
-    async ({ query: { query }, _userId }) => {
+    async ({ query: { query }, CheckToken: { _userId } }) => {
       const channelInfos = await ServiceChannel.Search(query, _userId);
 
       return {
@@ -197,7 +197,7 @@ export const channel = new Elysia({ prefix: "/channel" })
 
   .post(
     "/invite",
-    async ({ body: { channelId, userId }, _userId, server }) => {
+    async ({ body: { channelId, userId }, CheckToken: { _userId }, server }) => {
       //招待処理
       await ServiceChannel.Invite(channelId, userId, _userId);
 
@@ -236,7 +236,7 @@ export const channel = new Elysia({ prefix: "/channel" })
   )
   .post(
     "/kick",
-    async ({ body: { channelId, userId }, _userId, server }) => {
+    async ({ body: { channelId, userId }, CheckToken: { _userId }, server }) => {
       //キック処理
       await ServiceChannel.Kick(channelId, userId, _userId);
 
@@ -278,7 +278,7 @@ export const channel = new Elysia({ prefix: "/channel" })
     async ({
       body: { name, description, isArchived, channelId, viewableRole },
       server,
-      _userId
+      CheckToken: { _userId }
     }) => {
       const channelDataUpdated = await ServiceChannel.Update(
         channelId,
@@ -320,7 +320,7 @@ export const channel = new Elysia({ prefix: "/channel" })
   )
   .put(
     "/create",
-    async ({ body: { channelName, description = "" }, _userId }) => {
+    async ({ body: { channelName, description = "" }, CheckToken: { _userId } }) => {
       const newChannel = await ServiceChannel.Create(
         channelName,
         description,
@@ -348,7 +348,7 @@ export const channel = new Elysia({ prefix: "/channel" })
   )
   .delete(
     "/delete",
-    async ({ body: { channelId }, server, _userId }) => {
+    async ({ body: { channelId }, server, CheckToken: { _userId } }) => {
       //チャンネル削除処理
       await ServiceChannel.Delete(channelId, _userId, server);
 

--- a/src/components/Message/message.module.ts
+++ b/src/components/Message/message.module.ts
@@ -7,7 +7,7 @@ export const message = new Elysia({ prefix: "/message" })
   .use(Middleware.CheckToken)
   .get(
     "/:messageId",
-    async ({ params: { messageId }, _userId }) => {
+    async ({ params: { messageId }, CheckToken: { _userId } }) => {
       const message = await ServiceMessage.Get(messageId, _userId);
 
       return {
@@ -27,7 +27,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .get(
     "/get-new",
-    async ({ _userId }) => {
+    async ({ CheckToken: { _userId } }) => {
       const news = await ServiceMessage.GetNew(_userId);
 
       return {
@@ -44,7 +44,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .get(
     "/read-time/get",
-    async ({ _userId }) => {
+    async ({ CheckToken: { _userId } }) => {
       const readTime = await ServiceMessage.GetReadTime(_userId);
 
       return {
@@ -61,7 +61,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .post(
     "/read-time/update",
-    async ({ _userId, body: { channelId, readTime }, server }) => {
+    async ({ CheckToken: { _userId }, body: { channelId, readTime }, server }) => {
       const readTimeUpdated = await ServiceMessage.UpdateReadTime(
         channelId,
         readTime,
@@ -105,7 +105,7 @@ export const message = new Elysia({ prefix: "/message" })
         loadIndex,
         sort,
       },
-      _userId,
+      CheckToken: { _userId },
     }) => {
       const messages = await ServiceMessage.Search(
         content,
@@ -141,7 +141,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .post(
     "/file/upload",
-    async ({ body: { channelId, file }, _userId }) => {
+    async ({ body: { channelId, file }, CheckToken: { _userId } }) => {
       const fileId = await ServiceMessage.UploadFile(channelId, file, _userId);
 
       return {
@@ -186,7 +186,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .delete(
     "/delete",
-    async ({ body: { messageId }, _userId, server }) => {
+    async ({ body: { messageId }, CheckToken: { _userId }, server }) => {
       const messageDeleted = await ServiceMessage.Delete(messageId, _userId);
 
       //WSで通知
@@ -218,7 +218,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .get(
     "/inbox",
-    async ({ _userId }) => {
+    async ({ CheckToken: { _userId } }) => {
       //通知を取得する
       const inboxAll = await ServiceMessage.GetInbox(_userId);
 
@@ -236,7 +236,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .post(
     "/inbox/read",
-    async ({ body: { messageId }, _userId, server }) => {
+    async ({ body: { messageId }, CheckToken: { _userId }, server }) => {
       await ServiceMessage.ReadInbox(messageId, _userId);
 
       //WSで通知の既読を通知
@@ -268,7 +268,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .post(
     "/inbox/clear",
-    async ({ _userId, server }) => {
+    async ({ CheckToken: { _userId }, server }) => {
       await ServiceMessage.ClearInbox(_userId);
 
       //WSで通知の全既読を通知
@@ -294,7 +294,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .post(
     "/emoji-reaction",
-    async ({ body: { messageId, channelId, emojiCode }, _userId, server }) => {
+    async ({ body: { messageId, channelId, emojiCode }, CheckToken: { _userId }, server }) => {
       const reaction = await ServiceMessage.Reaction(
         messageId,
         channelId,
@@ -330,7 +330,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .get(
     "/who-reacted",
-    async ({ query: { messageId, emojiCode, cursor }, _userId }) => {
+    async ({ query: { messageId, emojiCode, cursor }, CheckToken: { _userId } }) => {
       //リアクションしたユーザーを取得
       const messageWithReactions = await ServiceMessage.GetWhoReacted(
         messageId,
@@ -358,7 +358,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .delete(
     "/delete-emoji-reaction",
-    async ({ body: { messageId, channelId, emojiCode }, _userId, server }) => {
+    async ({ body: { messageId, channelId, emojiCode }, CheckToken: { _userId }, server }) => {
       const reactionDeleted = await ServiceMessage.DeleteEmojiReaction(
         messageId,
         emojiCode,
@@ -398,7 +398,7 @@ export const message = new Elysia({ prefix: "/message" })
     "/send",
     async ({
       body: { channelId, message, fileIds, replyingMessageId },
-      _userId,
+      CheckToken: { _userId },
       server,
     }) => {
       //メッセージの保存処理
@@ -482,7 +482,7 @@ export const message = new Elysia({ prefix: "/message" })
   )
   .post(
     "/edit",
-    async ({ body: { messageId, message }, _userId, server }) => {
+    async ({ body: { messageId, message }, CheckToken: { _userId }, server }) => {
       const messageEditing = await ServiceMessage.Edit(
         messageId,
         message,

--- a/src/components/Role/role.module.ts
+++ b/src/components/Role/role.module.ts
@@ -29,7 +29,7 @@ export const role = new Elysia({ prefix: "/role" })
 
   .put(
     "/create",
-    async ({ body: { roleName, rolePower }, _userId, server }) => {
+    async ({ body: { roleName, rolePower }, CheckToken: { _userId }, server }) => {
       const newRole = await ServiceRole.Create(roleName, rolePower, _userId);
 
       //WSで通知
@@ -63,7 +63,7 @@ export const role = new Elysia({ prefix: "/role" })
   )
   .post(
     "/update",
-    async ({ body: { roleId, roleData }, _userId, server }) => {
+    async ({ body: { roleId, roleData }, CheckToken: { _userId }, server }) => {
       const roleUpdated = await ServiceRole.Update(roleId, roleData, _userId);
 
       //WSで通知
@@ -99,7 +99,7 @@ export const role = new Elysia({ prefix: "/role" })
   )
   .post(
     "/link",
-    async ({ body: { userId, roleId }, _userId, server }) => {
+    async ({ body: { userId, roleId }, CheckToken: { _userId }, server }) => {
       await ServiceRole.Link(userId, roleId, _userId);
 
       //WSで通知
@@ -126,7 +126,7 @@ export const role = new Elysia({ prefix: "/role" })
   )
   .post(
     "/unlink",
-    async ({ body: { userId, roleId }, _userId, server }) => {
+    async ({ body: { userId, roleId }, CheckToken: { _userId }, server }) => {
       await ServiceRole.Unlink(userId, roleId, _userId);
 
       //WSで通知
@@ -153,7 +153,7 @@ export const role = new Elysia({ prefix: "/role" })
   )
   .delete(
     "/delete",
-    async ({ body: { roleId }, _userId, server }) => {
+    async ({ body: { roleId }, CheckToken: { _userId }, server }) => {
       await ServiceRole.Delete(roleId, _userId);
 
       //WSで通知

--- a/src/components/Server/server.module.ts
+++ b/src/components/Server/server.module.ts
@@ -59,7 +59,7 @@ export const server = new Elysia({ prefix: "/server" })
   )
   .put(
     "/create-invite",
-    async ({ body: { inviteCode }, _userId }) => {
+    async ({ body: { inviteCode }, CheckToken: { _userId } }) => {
       const newInvite = await ServiceServer.CreateInvite(inviteCode, _userId);
 
       return {
@@ -245,7 +245,7 @@ export const server = new Elysia({ prefix: "/server" })
   )
   .put(
     "/custom-emoji/upload",
-    async ({ body: { emoji, emojiCode }, server, _userId }) => {
+    async ({ body: { emoji, emojiCode }, server, CheckToken: { _userId } }) => {
       const emojiUploaded = await ServiceServer.uploadCustomEmoji(
         emoji,
         emojiCode,

--- a/src/components/User/user.module.ts
+++ b/src/components/User/user.module.ts
@@ -112,7 +112,7 @@ export const user = new Elysia({ prefix: "/user" })
   )
   .get(
     "/search",
-    async ({ query: { username, joinedChannel, cursor }, _userId }) => {
+    async ({ query: { username, joinedChannel, cursor }, CheckToken: { _userId } }) => {
       const users = await ServiceUser.Search(
         _userId,
         username,
@@ -183,7 +183,7 @@ export const user = new Elysia({ prefix: "/user" })
   )
   .post(
     "/change-icon",
-    async ({ body: { icon }, _userId }) => {
+    async ({ body: { icon }, CheckToken: { _userId } }) => {
       await ServiceUser.ChangeIcon(icon, _userId);
 
       return {
@@ -202,7 +202,7 @@ export const user = new Elysia({ prefix: "/user" })
   )
   .post(
     "/change-banner",
-    async ({ _userId, body: { banner } }) => {
+    async ({ CheckToken: { _userId }, body: { banner } }) => {
       await ServiceUser.ChangeBanner(banner, _userId);
 
       return {
@@ -221,7 +221,7 @@ export const user = new Elysia({ prefix: "/user" })
   )
   .post(
     "/change-password",
-    async ({ body: { currentPassword, newPassword }, _userId }) => {
+    async ({ body: { currentPassword, newPassword }, CheckToken: { _userId } }) => {
       await ServiceUser.ChangePassword(currentPassword, newPassword, _userId);
 
       return {
@@ -242,7 +242,7 @@ export const user = new Elysia({ prefix: "/user" })
   )
   .post(
     "/profile-update",
-    async ({ body: { name, selfIntroduction }, _userId, server }) => {
+    async ({ body: { name, selfIntroduction }, CheckToken: { _userId }, server }) => {
       const userUpdated = await ServiceUser.UpdateProfile(
         _userId,
         name,
@@ -276,7 +276,7 @@ export const user = new Elysia({ prefix: "/user" })
   )
   .get(
     "/session",
-    async ({ _userId, query: { cursor }, cookie: { token } }) => {
+    async ({ CheckToken: { _userId }, query: { cursor }, cookie: { token } }) => {
       const sessions = await ServiceUser.GetSessions(_userId, token.value, cursor);
 
       return {
@@ -295,7 +295,7 @@ export const user = new Elysia({ prefix: "/user" })
   )
   .post(
     "/change-session-name",
-    async ({ _userId, body: { sessionId, name } }) => {
+    async ({ CheckToken: { _userId }, body: { sessionId, name } }) => {
       const updatedSession = await ServiceUser.ChangeSessionName(_userId, sessionId, name);
 
       return {
@@ -312,7 +312,7 @@ export const user = new Elysia({ prefix: "/user" })
   )
   .delete(
     "/session",
-    async ({ body: { sessionId }, cookie: { token }, _userId }) => {
+    async ({ body: { sessionId }, cookie: { token }, CheckToken: { _userId } }) => {
       await ServiceUser.RemoveSession(_userId, sessionId, token.value);
 
       return {
@@ -360,7 +360,7 @@ export const user = new Elysia({ prefix: "/user" })
   )
   .get(
     "/verify-token",
-    ({ _userId }) => {
+    ({ CheckToken: { _userId } }) => {
       //もし空ならトークンが無効
       if (_userId === "") {
         throw status(401, "Token is invalid");
@@ -430,7 +430,7 @@ export const user = new Elysia({ prefix: "/user" })
   .use(Middleware.CheckRoleTerm)
   .post(
     "/ban",
-    async ({ body: { userId }, server, _userId }) => {
+    async ({ body: { userId }, server, CheckToken: { _userId } }) => {
       const userBanned = await ServiceUser.Ban(userId, _userId);
 
       //WSで全体へ通知
@@ -460,7 +460,7 @@ export const user = new Elysia({ prefix: "/user" })
   )
   .post(
     "/unban",
-    async ({ body: { userId }, server, _userId }) => {
+    async ({ body: { userId }, server, CheckToken: { _userId } }) => {
       const userUnbanned = await ServiceUser.Unban(userId, _userId);
 
       //WSで全体へ通知


### PR DESCRIPTION
Middlewareのトークン認証処理から返す値が`*.controller.ts`の引数部分でわかりづらかった
今まで
```ts
...
.get(
  "/search",
  async ({ query: { query }, _userId  }) => {
  const channelInfos = await ServiceChannel.Search(query, _userId);
  ...
```
新しいやつ
```ts
...
.get(
  "/search",
  async ({ query: { query }, CheckToken: { _userId }  }) => {
  const channelInfos = await ServiceChannel.Search(query, _userId);
  ...
```